### PR TITLE
Solution for ES creation of ids

### DIFF
--- a/lib/Doctrine/Search/ElasticSearch/Client.php
+++ b/lib/Doctrine/Search/ElasticSearch/Client.php
@@ -54,7 +54,7 @@ class Client implements SearchClientInterface
     {
         $this->client = $client;
     }
-    
+
     /**
      * @return ElasticaClient
      */
@@ -62,7 +62,7 @@ class Client implements SearchClientInterface
     {
         return $this->client;
     }
-    
+
     /**
      * {@inheritDoc}
      */
@@ -71,10 +71,10 @@ class Client implements SearchClientInterface
         $type = $this->getIndex($class->index)->getType($class->type);
 
         $parameters = $this->getParameters($class->parameters);
-        
+
         $bulk = array();
-        foreach ($documents as $id => $document) {
-            $elasticadoc = new Document($id);
+        foreach ($documents as $document) {
+            $elasticadoc = new Document($document['id']);
             foreach($parameters as $name => $value) {
                 if(isset($document[$value])) {
                     if(method_exists($elasticadoc, "set{$name}")) {
@@ -102,7 +102,11 @@ class Client implements SearchClientInterface
     public function removeDocuments(ClassMetadata $class, array $documents)
     {
         $type = $this->getIndex($class->index)->getType($class->type);
-        $type->deleteIds(array_keys($documents));
+        $ids = array();
+        foreach($documents as $document){
+            $ids[] = $document['id'];
+        }
+        $type->deleteIds($ids);
     }
 
     /**
@@ -126,28 +130,28 @@ class Client implements SearchClientInterface
         } catch (NotFoundException $ex) {
             throw new NoResultException();
         }
-        
+
         return $document;
     }
-    
+
     public function findOneBy(ClassMetadata $class, $field, $value)
     {
         $query = new Query();
         $query->setVersion(true);
         $query->setSize(1);
-        
+
         $filter = new Term(array($field => $value));
         $query->setFilter($filter);
-        
+
         $results = $this->search($query, array($class));
-        
+
         if (!$results->count()) {
             throw new NoResultException();
         }
-        
+
         return $results[0];
     }
-    
+
     /**
      * {@inheritDoc}
      */
@@ -171,7 +175,7 @@ class Client implements SearchClientInterface
         }
         return $searchQuery;
     }
-    
+
     /**
      * {@inheritDoc}
      */
@@ -179,7 +183,7 @@ class Client implements SearchClientInterface
     {
         return $this->buildQuery($classes)->search($query);
     }
-    
+
     /**
      * {@inheritDoc}
      */
@@ -205,7 +209,7 @@ class Client implements SearchClientInterface
     {
         $this->getIndex($index)->delete();
     }
-    
+
     /**
      * {@inheritDoc}
      */
@@ -234,7 +238,7 @@ class Client implements SearchClientInterface
 
         return $type;
     }
-    
+
     /**
      * {@inheritDoc}
      */
@@ -263,7 +267,7 @@ class Client implements SearchClientInterface
             if (isset($fieldMapping->path)) {
                 $properties[$propertyName]['path'] = $fieldMapping->path;
             }
-            
+
             if (isset($fieldMapping->includeInAll)) {
                 $properties[$propertyName]['include_in_all'] = $fieldMapping->includeInAll;
             }
@@ -275,11 +279,11 @@ class Client implements SearchClientInterface
             if (isset($fieldMapping->boost)) {
                 $properties[$propertyName]['boost'] = $fieldMapping->boost;
             }
-            
+
             if (isset($fieldMapping->analyzer)) {
                 $properties[$propertyName]['analyzer'] = $fieldMapping->analyzer;
             }
-            
+
             if (isset($fieldMapping->indexName)) {
                 $properties[$propertyName]['index_name'] = $fieldMapping->indexName;
             }
@@ -295,7 +299,7 @@ class Client implements SearchClientInterface
 
         return $properties;
     }
-    
+
     /**
      * Generates parameter mapping from entity annotations
      *

--- a/lib/Doctrine/Search/UnitOfWork.php
+++ b/lib/Doctrine/Search/UnitOfWork.php
@@ -191,12 +191,16 @@ class UnitOfWork
         foreach ($objects as $object) {
             $document = $serialize ? $serializer->serialize($object) : $object;
 
-            $id = $object->getId();
-            if (!isset($id)) {
-                throw new DoctrineSearchException('Entity must have an id to be indexed');
+            if(!array_key_exists('id', $document)){
+                $id = $object->getId();
+                if (!isset($id)) {
+                    throw new DoctrineSearchException('Entity must have an id to be indexed');
+                } else {
+                    $document['id'] = $id;
+                }
             }
 
-            $documents[get_class($object)][$id] = $document;
+            $documents[get_class($object)][] = $document;
         }
 
         return $documents;


### PR DESCRIPTION
So I think this could be a solution for entities whose ids will be generated by elasticsearch. It works with multiple entities being stored. I see no problem to represent the id generation of ES in this lib, I think we have to support it.

For this solution there is honestly one little downside: You have to name your entity's id `$id`. But this is nevertheless the case, as `getId()` also expects the entities to name it something like `$id`. And to be honest: Who does not name it `$id`?

I still don't know what is wrong with this spaces. I use PHPStorm. This is not for all files of the lib, just for a few. Other files work correctly. Maybe this is some git issue?
