### PR TITLE
[WIP] Implemented DependentMappingDriver

### DIFF
--- a/lib/Doctrine/Search/Configuration.php
+++ b/lib/Doctrine/Search/Configuration.php
@@ -161,20 +161,38 @@ class Configuration
     }
 
     /**
-     * @param ObjectManager $entityManager
+     * @param ObjectManager $objectManager
      */
-    public function setEntityManager(ObjectManager $entityManager)
+    public function setObjectManager(ObjectManager $objectManager)
     {
-        $this->attributes['entityManager'] = $entityManager;
+        $this->attributes['objectManager'] = $objectManager;
     }
 
     /**
      * @return ObjectManager
      */
+    public function getObjectManager()
+    {
+        if (isset($this->attributes['objectManager'])) {
+            return $this->attributes['objectManager'];
+        }
+    }
+
+    /**
+     * @deprecated
+     */
+    public function setEntityManager(ObjectManager $objectManager)
+    {
+        $this->setObjectManager($objectManager);
+    }
+
+    /**
+     * @deprecated
+     */
     public function getEntityManager()
     {
-        if (isset($this->attributes['entityManager'])) {
-            return $this->attributes['entityManager'];
+        if (isset($this->attributes['objectManager'])) {
+            return $this->attributes['objectManager'];
         }
     }
 }

--- a/lib/Doctrine/Search/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/Search/Mapping/ClassMetadataFactory.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\Search\Mapping;
 
+use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Search\SearchManager;
 use Doctrine\Search\Configuration;
 use Doctrine\Common\Persistence\Mapping\AbstractClassMetadataFactory;
@@ -66,6 +67,15 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         $this->driver = $this->config->getMetadataDriverImpl();
         $this->evm = $this->sm->getEventManager();
         $this->initialized = true;
+
+        $om = $this->sm->getObjectManager();
+        if ($this->driver instanceof DependentMappingDriver && $om instanceof ObjectManager) {
+            $parentMetadataFactory = $om->getMetadataFactory();
+            if ($parentMetadataFactory instanceof AbstractClassMetadataFactory) {
+                $parentMetadataFactory->initialize();
+                $this->driver->setParentDriver($parentMetadataFactory->getDriver());
+            }
+        }
     }
 
     /**

--- a/lib/Doctrine/Search/Mapping/DependentMappingDriver.php
+++ b/lib/Doctrine/Search/Mapping/DependentMappingDriver.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Search\Mapping;
+
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
+
+
+
+/**
+ * If a driver implements this interface,
+ * it should delegate the getAllClassNames method to the parent driver.
+ *
+ * @author      Filip Procházka <filip@prochazka.su>
+ */
+interface DependentMappingDriver
+{
+
+    /**
+     * @param MappingDriver $driver
+     * @return void
+     */
+    public function setParentDriver(MappingDriver $driver);
+
+}

--- a/lib/Doctrine/Search/SearchManager.php
+++ b/lib/Doctrine/Search/SearchManager.php
@@ -53,7 +53,7 @@ class SearchManager implements ObjectManager
     /**
      * @var ObjectManager
      */
-    private $entityManager;
+    private $objectManager;
 
     /**
      * The event manager that is the central point of the event system.
@@ -95,27 +95,25 @@ class SearchManager implements ObjectManager
         $this->metadataFactory->setCacheDriver($this->configuration->getMetadataCacheImpl());
 
         $this->serializer = $this->configuration->getEntitySerializer();
-        $this->entityManager = $this->configuration->getEntityManager();
+        $this->objectManager = $this->configuration->getObjectManager();
 
         $this->unitOfWork = new UnitOfWork($this);
     }
 
     /**
-     * Inject a Doctrine 2 object manager
-     *
-     * @param ObjectManager $om
+     * @param ObjectManager $objectManager
      */
-    public function setEntityManager(ObjectManager $om)
+    public function setObjectManager(ObjectManager $objectManager)
     {
-        $this->entityManager = $om;
+        $this->objectManager = $objectManager;
     }
 
     /**
-     * @return ObjectManager|\Doctrine\ORM\EntityManager
+     * @return ObjectManager
      */
-    public function getEntityManager()
+    public function getObjectManager()
     {
-        return $this->entityManager;
+        return $this->objectManager;
     }
 
     /**
@@ -331,5 +329,26 @@ class SearchManager implements ObjectManager
 
     public function refresh($object)
     {
+    }
+
+
+    /**
+     * Inject a Doctrine 2 object manager
+     *
+     * @deprecated
+     * @param ObjectManager $om
+     */
+    public function setEntityManager(ObjectManager $om)
+    {
+        $this->setObjectManager($om);
+    }
+
+    /**
+     * @deprecated
+     * @return ObjectManager|\Doctrine\ORM\EntityManager
+     */
+    public function getEntityManager()
+    {
+        return $this->getObjectManager();
     }
 }


### PR DESCRIPTION
I don't like much how the driver paths has to be configured. I think it would be great, if you could connect the search metadata driver with the orm/odm metadata driver and reuse the `getAllClassNames` list from parent `ObjectManager`.

It's just an idea (I haven't yet tried to execute the code), what do you think?
