### PR TITLE
change license field to american english

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["elasticsearch", "solr", "lucene", "search", "odm", "orm"],
     "homepage": "https://github.com/doctrine/search",
     "type": "library",
-    "licence": "MIT",
+    "license": "MIT",
     "authors": [
         {
             "name": "Doctrine Search Community",


### PR DESCRIPTION
Fields have to match composer's schema definition

When running `composer validate --strict` composer detects following error:

```
doctrine/search is valid for simple usage with composer but has
strict errors that make it unable to be published as a package:
The property - licence - is not defined and the definition does not allow additional properties
```

The license field needs to american english and fit the schema according to https://getcomposer.org/doc/04-schema.md#license